### PR TITLE
Accept input from a file rather than an interface

### DIFF
--- a/pyDot11
+++ b/pyDot11
@@ -156,47 +156,32 @@ def main(args):
         packetParser = wpaParser(args, shake, ccmp, tkip)
 
     print 'pyDot11 up and running on tap{0}'.format(args.n)
-    
+
     ## Default direction of To-DS
     if not args.d or args.d == 'to':
         if not args.d:
             args.d = 'to'
         if args.t == 'wpa':
-            sniff(iface = args.i,
-                prn = packetParser,
-                lfilter = lambda x: x[Dot11].FCfield == 65L or x.haslayer(EAPOL),
-                store = 0)
+            lfilter = lambda x: x[Dot11].FCfield == 65L or x.haslayer(EAPOL)
         else:
-            sniff(iface = args.i,
-                            prn = packetParser,
-                            lfilter = lambda x: x[Dot11].FCfield == 65L,
-                            store = 0)
+            lfilter = lambda x: x[Dot11].FCfield == 65L
 
     ## Deal with 2-way
     elif args.d == 'both':
         if args.t == 'wpa':
-            sniff(iface = args.i,
-                prn = packetParser,
-                lfilter = lambda x: x[Dot11].FCfield == 65L or x[Dot11].FCfield == 66L or x.haslayer(EAPOL),
-                store = 0)
+            lfilter = lambda x: x[Dot11].FCfield == 65L or x[Dot11].FCfield == 66L or x.haslayer(EAPOL)
         else:
-            sniff(iface = args.i,
-                prn = packetParser,
-                lfilter = lambda x: x[Dot11].FCfield == 65L or x[Dot11].FCfield == 66L,
-                store = 0)
+            lfilter = lambda x: x[Dot11].FCfield == 65L or x[Dot11].FCfield == 66L
 
     ## Deal with From-DS
     elif args.d == 'from':
         if args.t == 'wpa':
-            sniff(iface = args.i,
-                prn = packetParser,
-                lfilter = lambda x: x[Dot11].FCfield == 66L or x.haslayer(EAPOL),
-                store = 0)
+            lfilter = lambda x: x[Dot11].FCfield == 66L or x.haslayer(EAPOL)
         else:
-            sniff(iface = args.i,
-                            prn = packetParser,
-                            lfilter = lambda x: x[Dot11].FCfield == 66L,
-                            store = 0)
+            lfilter = lambda x: x[Dot11].FCfield == 66L
+
+    sniff(iface = args.i, prn = packetParser, lfilter = lfiter, store = 0)
+
 
 
 if __name__ == '__main__':

--- a/pyDot11
+++ b/pyDot11
@@ -1,6 +1,7 @@
 #!/usr/bin/python2.7
 
 import argparse, os, subprocess, sys
+import scapy.utils
 
 def fromDecrypt(packet, args, *cryptoList):
     """Encompass steps for From-DS decrypt"""
@@ -46,7 +47,7 @@ def toDecrypt(packet, args, *cryptoList):
                     type = 0x800)/decodedPkt[IP],
         iface = 'tap{0}'.format(args.n),
         verbose = 0)
-        
+
 
 def pktFilter(packet):
     """ Verify it is an encrypted data packet"""
@@ -63,11 +64,11 @@ def wepParser(args):
 
         ## Verify we care
         if pktFilter(packet):
-            
+
             ## Both ways From-DS
             if args.d == 'both' and packet[Dot11].addr2 == args.b.lower():
                 fromDecrypt(packet, args)
-                
+
             ## Both ways To-DS
             elif args.d == 'both' and packet[Dot11].addr1 == args.b.lower():
                 toDecrypt(packet, args)
@@ -89,14 +90,14 @@ def wpaParser(args, shake, ccmp, tkip):
         try:
             if packet.haslayer(EAPOL):
                 shake.eapolGrab(packet)
-                
+
             ## Verify we care
             elif pktFilter(packet):
                 tgtMAC = False
-                
+
                 ## DEBUG
                 #print shake.availTgts
-                
+
                 ## MAC verification
                 if packet.addr1 in shake.availTgts:
                     tgtMAC = packet.addr1
@@ -111,7 +112,7 @@ def wpaParser(args, shake, ccmp, tkip):
                     ## Both ways From-DS
                     if args.d == 'both' and packet[Dot11].addr2 == args.b.lower():
                         fromDecrypt(packet, args, shake, ccmp, tkip, tgtMAC)
-                        
+
                     ## Both ways To-DS
                     elif args.d == 'both' and packet[Dot11].addr1 == args.b.lower():
                         toDecrypt(packet, args, shake, ccmp, tkip, tgtMAC)
@@ -134,14 +135,15 @@ def wpaParser(args, shake, ccmp, tkip):
 
 def main(args):
 
-    ## Setup the tap
-    if not args.n:
-        dev = Tap()
-        subprocess.check_call('ifconfig tap0 up'.format(args.n), shell = True)
-        args.n = 0
-    else:
-        dev = Tap(args.n)
-        subprocess.check_call('ifconfig tap{0} up'.format(args.n), shell = True)
+    if args.i:
+        ## Setup the tap
+        if not args.n:
+            dev = Tap()
+            subprocess.check_call('ifconfig tap0 up'.format(args.n), shell = True)
+            args.n = 0
+        else:
+            dev = Tap(args.n)
+            subprocess.check_call('ifconfig tap{0} up'.format(args.n), shell = True)
 
     ## Setup the encryption
     if args.t == 'wep':
@@ -180,8 +182,20 @@ def main(args):
         else:
             lfilter = lambda x: x[Dot11].FCfield == 66L
 
-    sniff(iface = args.i, prn = packetParser, lfilter = lfiter, store = 0)
-
+    if args.i:
+        sniff(iface = args.i, prn = packetParser, lfilter = lfiter, store = 0)
+    elif args.f:
+        if os.access(args.f, os.R_OK):
+            capture = scapy.utils.PcapReader(args.f)
+            for pkt in capture:
+                packetParser(pkt)
+        else:
+            sys.stderr.write("{}: Cannot open input file: {}; skipping\n"
+                             .format(sys.argv[0], pcap_file))
+    else:
+        # argparse should never allow this to happen
+        sys.stderr.write("{}: must specify either -f or -i option\n"
+                         .format(sys.argv[0]))
 
 
 if __name__ == '__main__':
@@ -198,10 +212,13 @@ if __name__ == '__main__':
     parser.add_argument('-e',
                         metavar = '<tgt ESSID>',
                         help = 'Target ESSID -------------- required for wpa')
-    parser.add_argument('-i',
-                        metavar = '<Sniffing NIC>',
-                        required = True,
-                        help = 'NIC to sniff with ----------------- required')
+    input_args = parser.add_mutually_exclusive_group(required=True)
+    input_args.add_argument('-i',
+                            metavar = '<Sniffing NIC>',
+                            help = 'NIC to sniff with')
+    input_args.add_argument('-f',
+                            metavar = '<PCAP File>',
+                            help = 'File from which to get packets')
     parser.add_argument('-n',
                         metavar = '<dev number>',
                         help = 'Device number for Tap interface [Default: 0]')
@@ -219,7 +236,7 @@ if __name__ == '__main__':
                         required = True,
                         help = 'Encryption type ------------------- required')
     args = parser.parse_args()
-    
+
     ## Paths and imports
     if args.o == 'pypy':
         pwd = os.getcwd()
@@ -230,5 +247,5 @@ if __name__ == '__main__':
     from scapy.sendrecv import sendp, sniff
     from scapy.layers.l2 import Ether, EAPOL
     from pyDot11 import *
-    
+
     main(args)


### PR DESCRIPTION
The first commit refactors the call to `sniff` to make the second commit simpler.  The second commit changes the pyDot11 script to accept a PCAP file for input as an alternative to an interface.

Sorry for the lines where spaces were deleted from blank lines.  My text editor did that automatically and I did not notice it.  If you prefer it the other way, I can re-do the commit.