### PR TITLE
Bit manipulation fixes

### DIFF
--- a/SRC/pyDot11/__init__.py
+++ b/SRC/pyDot11/__init__.py
@@ -75,12 +75,9 @@ def wpaEncrypt(encKey, origPkt, decodedPkt, PN, genFCS = True):
     newPkt = newPkt/dEverything
     encodedPkt = ccmpCrypto.encryptCCMP(newPkt, encKey, PN, genFCS)
 
-    ## Flip FCField bits accordingly
-    if encodedPkt[Dot11].FCfield == 1L:
-        encodedPkt[Dot11].FCfield = 65L
-    elif encodedPkt[Dot11].FCfield == 2L:
-        encodedPkt[Dot11].FCfield = 66L
-    
+    ## Set 'protected' bit in FCfield
+    encodedPkt[Dot11].FCfield = finalPkt[Dot11].FCfield | 0x40
+
     return encodedPkt
 
 ### Instantiations

--- a/SRC/pyDot11/lib/ccmp.py
+++ b/SRC/pyDot11/lib/ccmp.py
@@ -230,10 +230,7 @@ class Ccmp(object):
         decodedPkt = postPkt/LLC(str(stream))
 
         ## Flip FCField bits accordingly
-        if decodedPkt[Dot11].FCfield == 65L:
-            decodedPkt[Dot11].FCfield = 1L
-        elif decodedPkt[Dot11].FCfield == 66L:
-            decodedPkt[Dot11].FCfield = 2L
+        decodedPkt[Dot11].FCfield = decodedPkt.FCfield & ~0x40
 
         ## Return the decoded packet with or without FCS
         if genFCS is False:
@@ -339,7 +336,7 @@ class Ccmp(object):
         pload1 = bytearray(pload[offset:])
         self.xorRange(pload1, MIC, pload1, 8)
         encrypted = ccmphdr + encrypted + pload1
-        
+
         del pkt[LLC]
         finalPkt = pkt/Raw(encrypted)
 

--- a/SRC/pyDot11/lib/ccmp.py
+++ b/SRC/pyDot11/lib/ccmp.py
@@ -24,7 +24,7 @@ class Ccmp(object):
         return pkt[Dot11].FCfield & 0x4 > 0
 
     def order(self, pkt):
-        return pkt[Dot11].FCfield & 0x128 > 0
+        return pkt[Dot11].FCfield & 0x80 > 0
 
     def fragNum(self, pkt):
         if sys.byteorder == 'little':

--- a/SRC/pyDot11/lib/tkip.py
+++ b/SRC/pyDot11/lib/tkip.py
@@ -322,18 +322,15 @@ class Tkip(object):
 
         ## The data is proper in here
         finalPkt = postPkt.copy()/LLC(binascii.unhexlify(dEverything.replace(' ', '')))
-       
+
         ## Flip FCField bits accordingly
-        if finalPkt[Dot11].FCfield == 65L:
-            finalPkt[Dot11].FCfield = 1L
-        elif finalPkt[Dot11].FCfield == 66L:
-            finalPkt[Dot11].FCfield = 2L
+        decodedPkt[Dot11].FCfield = decodedPkt.FCfield & ~0x40
 
         ## Calculate and append the FCS
         crcle = crc32(str(finalPkt[Dot11])) & 0xffffffff
 
         if sys.byteorder == "little":
-            
+
             ## Convert to big endian
             crc = struct.pack('<L', crcle)
             ## Convert to long

--- a/SRC/pyDot11/lib/wep.py
+++ b/SRC/pyDot11/lib/wep.py
@@ -52,12 +52,9 @@ class Wep(object):
 
         ## Add the stream to LLC
         decodedPkt = postPkt/LLC(str(stream))
-        
+
         ## Flip FCField bits accordingly
-        if decodedPkt[Dot11].FCfield == 65L:
-            decodedPkt[Dot11].FCfield = 1L
-        elif decodedPkt[Dot11].FCfield == 66L:
-            decodedPkt[Dot11].FCfield = 2L
+        decodedPkt[Dot11].FCfield = decodedPkt.FCfield & ~0x40
 
         ## Return the decoded packet with or without FCS
         if genFCS is False:
@@ -103,10 +100,7 @@ class Wep(object):
         encodedPacket = pkt/Dot11WEP(iv = iVal, keyid = 0, wepdata = stream)
 
         ## Flip FCField bits accordingly
-        if encodedPacket[Dot11].FCfield == 1L:
-            encodedPacket[Dot11].FCfield = 65L
-        elif encodedPacket[Dot11].FCfield == 2L:
-            encodedPacket[Dot11].FCfield = 66L
+        decodedPkt[Dot11].FCfield = decodedPkt.FCfield | 0x40
 
         ## Add the ICV
         #encodedPacket[Dot11WEP].icv = int(self.pt.endSwap(hex(crc32(str(encodedPacket[Dot11])[0:-4]) & 0xffffffff)), 16)


### PR DESCRIPTION
My traces have some WPA packets with the retransmit bit set in the FCfield.  pyDot11 decrypted the payload correctly, but the protected bit in FCfield was not cleared.  It looks like the logic in 1.1.0 and before only handles certain bit patterns.  I modified the CCMP decryption code to clear the protected bit regardless of how the other bits are set.  This change fixed that problem for me.

There were a few other places with the same logic for clearing 'protected' and similar logic for setting 'protected' when encrypting, so I updated them, too.  I have not tested those changes, as I don't really have any TKIP or WEP datasets right now.

In checking for FCfield everywhere, I found what is probably a typo in the code checking the 'order' bit in FCfield.  It looks like an extra '0x' was accidentally added in front of 128.  I converted it to hex for consistency with the others.