### PR TITLE
Generate 32-bit FCS even when high bits are zero

### DIFF
--- a/SRC/pyDot11/lib/ccmp.py
+++ b/SRC/pyDot11/lib/ccmp.py
@@ -239,7 +239,7 @@ class Ccmp(object):
         if genFCS is False:
             return decodedPkt
         else:
-            return decodedPkt/Padding(load = binascii.unhexlify(self.pt.endSwap(hex(crc32(str(decodedPkt[Dot11])) & 0xffffffff)).replace('0x', '')))
+            return decodedPkt/Padding(load = struct.pack('<I', crc32(str(decodedPkt[Dot11])) & 0xffffffff))
 
 
     def encryptCCMP(self, pkt, aesKey, PN, genFCS):
@@ -345,6 +345,6 @@ class Ccmp(object):
 
         ## Return the encrypted packet with or without FCS
         if genFCS is True:
-            return finalPkt/Raw(binascii.unhexlify(self.pt.endSwap(hex(crc32(str(finalPkt[Dot11])) & 0xffffffff)).replace('0x', '')))
+            return finalPkt/Raw(struct.pack('<I', crc32(str(finalPkt[Dot11])) & 0xffffffff))
         else:
             return finalPkt

--- a/SRC/pyDot11/lib/utils.py
+++ b/SRC/pyDot11/lib/utils.py
@@ -1,3 +1,5 @@
+import struct
+
 from scapy.utils import hexstr, PcapReader, PcapWriter, rdpcap, wrpcap
 from scapy.plist import PacketList
 from zlib import crc32
@@ -118,56 +120,14 @@ class Packet(object):
                 return pktFlow(' '.join(streamList[:-qty]).replace(' ', ''), output)
 
 
-    def endSwap(self, value):
-        """Takes an object and reverse Endians the bytes
-
-        Useful for crc32 within 802.11:
-        Autodetection logic built in for the following situations:
-        Will take the stryng '0xaabbcc' and return string '0xccbbaa'
-        Will take the integer 12345 and return integer 14640
-        Will take the bytestream string of 'aabbcc' and return string 'ccbbaa'
-        """
-        try:
-            value = hex(value).replace('0x', '')
-            sType = 'int'
-        except:
-            if '0x' in value:
-                sType = 'hStr'
-            else:
-                sType = 'bStr'
-            value = value.replace('0x', '')
-            
-        start = 0
-        end = 2
-        swapList = []
-        for i in range(len(value)/2):
-            swapList.append(value[start:end])
-            start += 2
-            end += 2
-        swapList.reverse()
-        s = ''
-        for i in swapList:
-            s += i
-        
-        if sType == 'int':
-            s = int(s, 16)
-        elif sType == 'hStr':
-            s = '0x' + s
-        return s
-
-
     def fcsGen(self, frame, start = None, end = None, mLength = 0, output = 'bytes'):
         """Return the FCS for a given frame"""
         frame = str(frame)
         frame = frame[start:end]
-        frame = crc32(frame) & 0xffffffff
-        fcs = hex(frame).replace('0x', '')
-        while len(fcs) < mLength:
-            fcs = '0' + fcs
-        fcs = self.endSwap(fcs)
-        if output == 'bytes':
-            return fcs
-        elif output == 'str':
-            return binascii.unhexlify(fcs)
-        else:
-            return fcs
+        fcs = crc32(frame) & 0xffffffff
+        if output != 'int':
+            # Make `fcs` into a unhexlified string
+            fcs = struct.pack('<I', fcs)
+            if output == 'bytes':
+                return binascii.hexlify(fcs)
+        return fcs

--- a/SRC/tests/test_utils.py
+++ b/SRC/tests/test_utils.py
@@ -1,0 +1,81 @@
+import binascii
+import unittest
+
+from scapy.layers.dot11 import Dot11, Dot11Beacon, Dot11Elt, Dot11QoS, RadioTap
+from scapy.layers.inet import IP, UDP, TCP
+from scapy.layers.inet6 import IPv6
+from scapy.layers.l2 import *
+from scapy.packet import Padding, Raw
+
+import pyDot11.lib.utils as p11
+
+
+class TestPacket(unittest.TestCase):
+    """Test public methods the Packet class"""
+
+    def setUp(self):
+        self.pkt = RadioTap(version=0, pad=0, present=2686468138L, len=42,
+                notdecoded=' \x08\x00\xa0 \x08\x00\x00\x10\x00<\x14@\x01\xc8\x00\x00\x00e\x00\x04\x04\x92\x00\x00\x00\x01\x00\x00\x00\xc6\x00\xc8\x01')\
+            /Dot11(proto=0L, FCfield=2L, subtype=8L, SC=1248, type=2L, ID=11264,
+                addr1='b8:08:cf:09:0a:8c',
+                addr2='16:91:82:b6:62:15',
+                addr3='16:91:82:b6:62:13',
+                addr4=None)\
+            /Dot11QoS(TID=0L, TXOP=0, Reserved=0L, EOSP=0L)\
+            /LLC(dsap=170, ssap=170, ctrl=3)/SNAP(OUI=0, code=2048)\
+            /IP(frag=0L, src='65.200.22.161', proto=6, tos=0,
+                dst='192.168.3.140', chksum=38717, len=842, options=[],
+                version=4L, flags=2L, ihl=5L, ttl=64, id=33747)\
+            /TCP(reserved=0L, seq=2807109953, ack=2395100790, dataofs=8L,
+                urgptr=0, window=3620, flags=24L, chksum=3646, dport=48728,
+                sport=80, options=[('NOP', None), ('NOP', None),
+                    ('Timestamp', (300784283, 225172108))])\
+            /Raw(load="""\
+HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nExpires: 0\r\nCache-Control: no-cache\r\nPragma: no-cache\r\nConnection: close\r\n\r\n
+<html>
+  <head>
+    <noscript>
+      <meta http-equiv=Refresh Content="0; URL=http://192.168.3.1:10080/ui/dynamic/guest-login.html">
+    </noscript>
+    <script language=\'javascript\' type=\'text/javascript\'>function init(_frm) { if (_frm.sent.value == 0) { _frm.sent.value=1; _frm.submit(); } }</script>
+  </head>
+  <body onload=init(auth)>
+    <form name=authaction=\'http://192.168.3.1:10080/ui/dynamic/guest-login.html\' METHOD=GET>
+      <input type=hidden name=\'mac_addr\' value=\'b8:08:cf:09:0a:8c\'>
+      <input type=hidden name=\'url\' value=\'http://detectportal.firefox.com/success.txt\'>
+      <input type=hidden name=\'ip_addr\' value=\'192.168.3.140\'>
+      <input type=hidden id=sent value=\'0\'>
+    </form>
+  </body>
+</html>""")\
+            /Padding(load='\x95\x07\xd6\xd4')
+
+    def test_fcsGenIntOutput(self):
+        expected = 0xcd925e20
+        pd11pkt = p11.Packet()
+        actual = pd11pkt.fcsGen(self.pkt[Dot11], end = -4, output = 'int')
+        self.assertEqual(expected, actual,
+                         'expected 0x{:08x}, but got 0x{:08x}'
+                         .format(expected, actual))
+
+    def test_fcsGenByteOutput(self):
+        expected = '205e92cd'
+        pd11pkt = p11.Packet()
+        actual = pd11pkt.fcsGen(self.pkt[Dot11], end = -4, output = 'bytes')
+        self.assertEqual(expected, actual,
+                         'expected "{:8s}", but got "{:8s}"'
+                         .format(expected, actual))
+
+    def test_fcsGenStringOutput(self):
+        expected = '\x20\x5e\x92\xcd'
+        expected_str = binascii.hexlify(expected)
+        pd11pkt = p11.Packet()
+        actual = pd11pkt.fcsGen(self.pkt[Dot11], end = -4, output = 'str')
+        actual_str = binascii.hexlify(actual)
+        self.assertEqual(expected, actual,
+                         'expected "{:8s}", but got "{:8s}"'
+                         .format(expected_str, actual_str))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request is to address Issue  #10, where I was seeing 1 byte being dropped occasionally.  I also noticed some cases where the FCS was incorrect, but thought that might be due to some other manipulations I am doing unrelated to pyDot11, and this fix seems to have cleaned those up.

I have only tested WPA with CCMP.  The logic is the same everywhere, so I replicated it everywhere the same logic occurred.

The pyDot11.utils.Packet.endSwap() method was adapting the number of bytes
swapped based on the number of bytes needed to represent the integer or
string passed in.  Every place endSwap was used was appending a 32-bit
FCS, so when the high bits of the input number were zero, an incorrect
FCS was computed.

Every place endSwap was called is trying to pack bytes into a frame in
little endian order, so switch the code to use struct.pack and directly
pack to little endian.  Also, delete endSwap so it does not accidentally
get used.

Calling pyDot11.utils.Packet.fcsGen() would centralize the byteswapping
and CRC computation logic and make the code easier to understand.
However, many places fcsGen would be used do not already allocate a
pyDot11.utils.Packet.  Probably it would be best to make fcsGen a free
function or to make it a class method of the pyDot11.utils.Packet class.

Also added a few quick and dirty unit tests for fcsGen.  The tests can be
run by typing `pytest` while in the SRC directory.  The expected values
were computed by running the tests, so might need to be adjusted.